### PR TITLE
Dev

### DIFF
--- a/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-1.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-1.cfg
@@ -82,5 +82,10 @@ PART
 			rate = 0.0125
 		}
 	}
-
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 100
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-2.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-2.cfg
@@ -82,4 +82,10 @@ PART
 			rate = 0.0375
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 200
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-3.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-conformal/radiator-conformal-3.cfg
@@ -81,4 +81,10 @@ PART
 			rate = 0.375
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = -1
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-1.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-1.cfg
@@ -83,5 +83,11 @@ PART
 			rate = 0.0375
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 75
+	}
 
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-2.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-2.cfg
@@ -84,4 +84,10 @@ PART
 			rate = 0.25
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 600
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-3.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-deployable/radiator-universal-3.cfg
@@ -83,4 +83,10 @@ PART
 			rate = 0.3125
 		}
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = -1
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-1.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-1.cfg
@@ -67,5 +67,10 @@ PART
 			rate = 0.0375
 		}
 	}
-
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 200
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-2.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-2.cfg
@@ -67,5 +67,10 @@ PART
 			rate = 0.00625
 		}
 	}
-
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 75
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-3.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-3.cfg
@@ -68,5 +68,10 @@ PART
 			rate = 0.15
 		}
 	}
-
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = -1
+	}
 }

--- a/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-4.cfg
+++ b/GameData/HeatControl/Parts/Radiators/radiator-fixed/radiator-fixed-4.cfg
@@ -68,5 +68,10 @@ PART
 			rate = 0.5
 		}
 	}
-
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = -1
+	}
 }


### PR DESCRIPTION
Adding Cargo capabilities to Heat Control radiator parts.

Modeled the volume values to align close to the Stock Radiator parts from a balance standpoint.

As Heat Control parts are slightly smaller than the similar Stock sized parts, I took the 'packedVolume' from the closest sized Stock parts and reduced slightly for the HC parts.  The larger parts I set the volume to -1, which enables manipulation by an Engineer in the field, but does not allow it to be stored in a Cargo Container ( IE, too big ).

I left the micro-channel and surface mount-curved radiators alone for now, as my thoughts are those require specialized skills to install and should likely be limited to VAB.

Fixed-1 Beta = 200L
Fixed-2 Alpha = 75L
Fixed-3 Gamma = -1
Fixed-4 Delta = -1

Conformal-1 = 100L
Conformal-2 = 200L
Conformal-3 = -1

Universal-1 = 75L ( I think this is a bit low, but is balanced with the Stock Small Radiator )
Universal-2 = 600L
Universal-3 = -1